### PR TITLE
Bump OpenPDF from 1.3.13 to 1.3.26

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
 
     implementation("com.google.code.findbugs:jsr305:3.0.2")
 
-    implementation("com.github.librepdf:openpdf:1.3.13")
+    implementation("com.github.librepdf:openpdf:1.3.26")
     implementation("org.apache.xmlgraphics:fop:2.4") {
         exclude(group = "com.sun.media", module = "jai-codec")
         exclude(group = "javax.media", module = "jai-core")


### PR DESCRIPTION
Fixes the exception occurred at PDF generation:
```
com.lowagie.text.DocumentException: java.lang.NullPointerException
	at com.lowagie.text.pdf.PdfDocument.add(PdfDocument.java:770)
	at com.lowagie.text.Document.add(Document.java:293)
	at io.github.eroshenkoam.allure.AllurePDFGenerator.printTestResultDetails(AllurePDFGenerator.java:135)
	at io.github.eroshenkoam.allure.AllurePDFGenerator.generate(AllurePDFGenerator.java:104)
	at io.github.eroshenkoam.allure.MainCommand.run(MainCommand.java:42)
	at picocli.CommandLine.executeUserObject(CommandLine.java:1769)
	at picocli.CommandLine.access$900(CommandLine.java:145)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2141)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2108)
	at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:1975)
	at picocli.CommandLine.execute(CommandLine.java:1904)
	at io.github.eroshenkoam.allure.AllurePDF.main(AllurePDF.java:13)
	Suppressed: java.lang.NullPointerException
Caused by: java.lang.NullPointerException
	at com.lowagie.text.pdf.FopGlyphProcessor.convertToBytesWithGlyphs(FopGlyphProcessor.java:41)
	at com.lowagie.text.pdf.FontDetails.convertToBytes(FontDetails.java:222)
	at com.lowagie.text.pdf.PdfContentByte.showText2(PdfContentByte.java:1504)
	at com.lowagie.text.pdf.PdfContentByte.showText(PdfContentByte.java:1514)
	at com.lowagie.text.pdf.PdfDocument.writeLineToContent(PdfDocument.java:1695)
	at com.lowagie.text.pdf.PdfDocument.flushLines(PdfDocument.java:1342)
	at com.lowagie.text.pdf.PdfDocument.newPage(PdfDocument.java:886)
	at com.lowagie.text.pdf.PdfDocument.carriageReturn(PdfDocument.java:1254)
	at com.lowagie.text.pdf.PdfDocument.add(PdfDocument.java:542)
	... 11 more
```